### PR TITLE
Remove 3rd party mock library. As of Python 23, it's in the standard …

### DIFF
--- a/tests/hamcrest_unit_test/base_description_test.py
+++ b/tests/hamcrest_unit_test/base_description_test.py
@@ -1,9 +1,10 @@
 # coding: utf-8
+from unittest.mock import sentinel
+
 import pytest
 from hamcrest.core.base_description import BaseDescription
 from hamcrest.core.helpers.ismock import MOCKTYPES
 from hamcrest.core.selfdescribing import SelfDescribing
-from mock import sentinel
 
 __author__ = "Chris Rose"
 __copyright__ = "Copyright 2015 hamcrest.org"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist = py35,py36,py37,py38,pypy2.7,pypy3.6,docs-py3
 commands  = {envbindir}/py.test []
             {envpython} tests/object_import.py
 deps      = pytest
-            mock
             pytest-cov
 
 [testenv:jython]


### PR DESCRIPTION
…library.